### PR TITLE
feat: wire newsletter to real subscribe flow, update sender domain

### DIFF
--- a/app/api/newsletter/route.js
+++ b/app/api/newsletter/route.js
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { Resend } from "resend";
+import { dbConnect } from "@/service/mongo";
+import { Subscriber } from "@/models/subscriber-model";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function POST(req) {
+    try {
+        const { email } = await req.json();
+
+        if (!email || !EMAIL_REGEX.test(email)) {
+            return NextResponse.json(
+                { message: "Please enter a valid email address" },
+                { status: 400 }
+            );
+        }
+
+        await dbConnect();
+
+        const normalizedEmail = email.toLowerCase().trim();
+        const existing = await Subscriber.findOne({ email: normalizedEmail });
+        if (existing) {
+            return NextResponse.json(
+                { message: "You're already subscribed" },
+                { status: 200 }
+            );
+        }
+
+        await Subscriber.create({ email: normalizedEmail });
+
+        try {
+            await resend.emails.send({
+                from: "AirBnB <noreply@ashrafulislam.im>",
+                to: normalizedEmail,
+                subject: "Welcome to the AirBnB newsletter",
+                html: `
+                    <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+                        <h1 style="color: #009688;">You're in!</h1>
+                        <p>Thanks for subscribing. You'll now get exclusive deals, travel tips and flash sale alerts straight to your inbox.</p>
+                    </div>
+                `,
+            });
+        } catch (emailError) {
+            // Subscriber is saved either way; email delivery is best-effort.
+            console.error("Failed to send newsletter welcome email:", emailError);
+        }
+
+        return NextResponse.json(
+            { message: "Subscribed successfully" },
+            { status: 201 }
+        );
+    } catch (error) {
+        console.error("Error subscribing to newsletter:", error);
+        return NextResponse.json(
+            { message: "Failed to subscribe" },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/send-email/route.js
+++ b/app/api/send-email/route.js
@@ -24,7 +24,7 @@ export const POST = async (req) => {
         }
 
         const emailResponse = await resend.emails.send({
-            from: "AirBnB <noreply@aihridoy.com>",
+            from: "AirBnB <noreply@ashrafulislam.im>",
             to,
             subject,
             html,

--- a/components/Newsletter.jsx
+++ b/components/Newsletter.jsx
@@ -23,9 +23,18 @@ const Newsletter = () => {
 
     setIsLoading(true);
 
-    // Simulate API call
-    setTimeout(() => {
-      setIsLoading(false);
+    try {
+      const response = await fetch("/api/newsletter", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || "Failed to subscribe");
+      }
+
       setIsSubmitted(true);
       setEmail("");
 
@@ -33,7 +42,11 @@ const Newsletter = () => {
       setTimeout(() => {
         setIsSubmitted(false);
       }, 5000);
-    }, 1500);
+    } catch (error) {
+      setEmailError(error.message || "Something went wrong. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const benefits = [

--- a/models/subscriber-model.js
+++ b/models/subscriber-model.js
@@ -1,0 +1,17 @@
+import mongoose, { Schema } from "mongoose";
+
+const subscriberSchema = new Schema(
+    {
+        email: {
+            type: String,
+            required: true,
+            unique: true,
+            lowercase: true,
+            trim: true,
+        },
+    },
+    { timestamps: true }
+);
+
+export const Subscriber =
+    mongoose.models.subscribers ?? mongoose.model("subscribers", subscriberSchema);


### PR DESCRIPTION
## Summary
- Sender domain switched to verified `ashrafulislam.im` (was `noreply@aihridoy.com`, unverified)
- Newsletter form was fake (`setTimeout`, no real subscribe): added `Subscriber` model + public `/api/newsletter` route that validates the email, persists the subscriber, sends a welcome email via Resend, and is idempotent on duplicate signup
- `Newsletter.jsx` now calls the real endpoint

## Test plan
- [x] `npm run lint` clean
- [x] Live: POST new email -> 201, subscriber saved, welcome email sent
- [x] Live: POST duplicate email -> 200 "already subscribed"
- [x] Live: POST invalid email -> 400

Claude-Session: https://claude.ai/code/session_01FLho1PNDHYJfTEAVLRjBr1