### PR TITLE
feat: add 6 new homepage sections

### DIFF
--- a/app/details/[id]/page.js
+++ b/app/details/[id]/page.js
@@ -14,6 +14,7 @@ import Reserve from "@/components/Reserve";
 import Reviews from "@/components/Reviews";
 import SocialShare from "@/components/SocialShare";
 import SuggestedHotels from "@/components/SuggestedHotels";
+import TrackRecentlyViewed from "@/components/TrackRecentlyViewed";
 import Image from "next/image";
 import {
   Star,
@@ -113,6 +114,7 @@ const HotelDetailsPage = async ({ params }) => {
 
   return (
     <>
+      <TrackRecentlyViewed hotelId={_id} />
       <Navbar />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex flex-col sm:flex-row justify-between gap-4 mb-6">

--- a/app/page.js
+++ b/app/page.js
@@ -1,13 +1,18 @@
 import AnnounceBar from "@/components/AnnounceBar";
+import FAQ from "@/components/FAQ";
 import Footer from "@/components/Footer";
-import AnimatedHeroBanner from "@/components/Hero";
 import HeroSection from "@/components/HeroSection";
 import HotelListing from "@/components/HotelListing";
 import HotelsCategory from "@/components/HotelsCategory";
+import HowItWorks from "@/components/HowItWorks";
 import Navbar from "@/components/Navbar";
 import Newsletter from "@/components/Newsletter";
 import Offer from "@/components/Offer";
+import PopularDestinations from "@/components/PopularDestinations";
+import RecentlyViewed from "@/components/RecentlyViewed";
+import Testimonials from "@/components/Testimonials";
 import TopRatedHotels from "@/components/TopRatedHotel";
+import WhyBookWithUs from "@/components/WhyBookWithUs";
 import HotelGridSkeleton from "@/components/skeletons/HotelGridSkeleton";
 import { Suspense } from "react";
 
@@ -27,8 +32,14 @@ export default function Home() {
         <HotelListing />
       </Suspense>
       <HotelsCategory />
+      <PopularDestinations />
+      <RecentlyViewed />
       <TopRatedHotels />
+      <Testimonials />
+      <WhyBookWithUs />
+      <HowItWorks />
       <Offer />
+      <FAQ />
       <Newsletter />
       <Footer />
     </>

--- a/components/FAQ.jsx
+++ b/components/FAQ.jsx
@@ -1,0 +1,57 @@
+import { ChevronDown } from "lucide-react";
+
+const FAQS = [
+  {
+    q: "How do I book a hotel?",
+    a: "Browse or search for a hotel, open its details page, pick your dates and guests, then confirm your reservation and payment.",
+  },
+  {
+    q: "Can I cancel or change my booking?",
+    a: "Yes, most bookings can be cancelled free of charge up to 48 hours before check-in from your dashboard's bookings page.",
+  },
+  {
+    q: "What payment methods are accepted?",
+    a: "We accept all major credit and debit cards. Payment is processed securely at the time of booking.",
+  },
+  {
+    q: "Is my payment information secure?",
+    a: "Yes, all transactions are encrypted and processed following industry-standard security practices.",
+  },
+  {
+    q: "How do I contact a hotel host?",
+    a: "Once booked, host details are available on your booking confirmation and dashboard for any questions about your stay.",
+  },
+];
+
+export default function FAQ() {
+  return (
+    <section className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <div className="text-center mb-10">
+        <h2 className="font-serif text-4xl md:text-5xl text-ink mb-4">
+          Frequently Asked Questions
+        </h2>
+        <p className="text-lg text-muted">
+          Everything you need to know before you book
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {FAQS.map(({ q, a }) => (
+          <details
+            key={q}
+            className="group bg-surface border border-hairline rounded-xl px-5 py-4"
+          >
+            <summary className="flex items-center justify-between cursor-pointer list-none font-semibold text-ink">
+              {q}
+              <ChevronDown
+                className="w-5 h-5 text-muted transition-transform duration-200 group-open:rotate-180"
+                aria-hidden="true"
+              />
+            </summary>
+            <p className="text-sm text-muted mt-3 leading-relaxed">{a}</p>
+          </details>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/HotelListing.jsx
+++ b/components/HotelListing.jsx
@@ -58,7 +58,7 @@ const HotelListing = () => {
   }
 
   return (
-    <section className="mt-10 px-6 min-h-screen">
+    <section id="hotel-listing" className="mt-10 px-6 min-h-screen">
       <motion.div
         initial={prefersReducedMotion ? false : { opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/components/HowItWorks.jsx
+++ b/components/HowItWorks.jsx
@@ -1,0 +1,47 @@
+import { Search, CalendarCheck, PartyPopper } from "lucide-react";
+
+const STEPS = [
+  {
+    icon: Search,
+    title: "Search",
+    text: "Browse hotels by category, destination, or dates to find your match.",
+  },
+  {
+    icon: CalendarCheck,
+    title: "Book",
+    text: "Reserve your room in a few clicks with instant confirmation.",
+  },
+  {
+    icon: PartyPopper,
+    title: "Stay",
+    text: "Check in and enjoy a stay tailored to how you like to travel.",
+  },
+];
+
+export default function HowItWorks() {
+  return (
+    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <div className="text-center mb-12">
+        <h2 className="font-serif text-4xl md:text-5xl text-ink mb-4">
+          How It Works
+        </h2>
+        <p className="text-lg text-muted max-w-2xl mx-auto">
+          Three simple steps between you and your next getaway
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 relative">
+        {STEPS.map(({ icon: Icon, title, text }, i) => (
+          <div key={title} className="text-center relative">
+            <div className="mx-auto mb-4 w-16 h-16 rounded-full bg-brass-dark flex items-center justify-center">
+              <Icon className="w-7 h-7 text-cream" aria-hidden="true" />
+            </div>
+            <span className="text-sm font-semibold text-brass-dark">Step {i + 1}</span>
+            <h3 className="font-serif text-xl text-ink mt-1 mb-2">{title}</h3>
+            <p className="text-sm text-muted max-w-xs mx-auto">{text}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/PopularDestinations.jsx
+++ b/components/PopularDestinations.jsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import Image from "next/image";
+import { MapPin } from "lucide-react";
+import { getAllHotels } from "@/app/action";
+import { useSearch } from "@/contexts/SearchContext";
+import Skeleton from "./skeletons/Skeleton";
+import { fadeUp, stagger } from "@/lib/motion";
+
+export default function PopularDestinations() {
+  const [destinations, setDestinations] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const { setSearchQuery } = useSearch();
+  const prefersReducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await getAllHotels();
+        const hotels = res?.hotels ?? [];
+
+        const byLocation = new Map();
+        for (const hotel of hotels) {
+          const loc = hotel.location;
+          if (!loc) continue;
+          if (!byLocation.has(loc)) {
+            byLocation.set(loc, { location: loc, count: 0, image: hotel.images?.[0] });
+          }
+          byLocation.get(loc).count += 1;
+        }
+
+        const top = [...byLocation.values()]
+          .sort((a, b) => b.count - a.count)
+          .slice(0, 8);
+
+        setDestinations(top);
+      } catch (e) {
+        console.error("Failed to load destinations:", e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleSelect = (location) => {
+    setSearchQuery(location);
+    document.getElementById("hotel-listing")?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  if (!loading && destinations.length === 0) return null;
+
+  return (
+    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <div className="text-center mb-10">
+        <h2 className="font-serif text-4xl md:text-5xl text-ink mb-4">
+          Popular Destinations
+        </h2>
+        <p className="text-lg text-muted max-w-2xl mx-auto">
+          Handpicked cities and regions our guests love most
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+          {[...Array(8)].map((_, i) => (
+            <Skeleton key={i} className="h-40 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : (
+        <motion.div
+          initial={prefersReducedMotion ? false : "hidden"}
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={stagger}
+          className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4"
+        >
+          {destinations.map((dest) => (
+            <motion.button
+              key={dest.location}
+              variants={fadeUp}
+              onClick={() => handleSelect(dest.location)}
+              className="group relative h-40 w-full rounded-xl overflow-hidden text-left"
+            >
+              <Image
+                src={dest.image || "https://placehold.co/400x300"}
+                alt={dest.location}
+                fill
+                sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+                className="object-cover transition-transform duration-500 group-hover:scale-105"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-ink/80 via-ink/10 to-transparent" />
+              <div className="absolute bottom-3 left-3 right-3 text-cream">
+                <div className="flex items-center gap-1 font-serif text-lg">
+                  <MapPin className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+                  <span className="line-clamp-1">{dest.location}</span>
+                </div>
+                <p className="text-xs text-cream/70">
+                  {dest.count} {dest.count === 1 ? "hotel" : "hotels"}
+                </p>
+              </div>
+            </motion.button>
+          ))}
+        </motion.div>
+      )}
+    </section>
+  );
+}

--- a/components/RecentlyViewed.jsx
+++ b/components/RecentlyViewed.jsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { getAllHotels, getReviews } from "@/app/action";
+import { getRecentlyViewed } from "@/lib/recentlyViewed";
+import Hotel from "./Hotel";
+import HotelGridSkeleton from "./skeletons/HotelGridSkeleton";
+import { fadeUp, stagger } from "@/lib/motion";
+
+const calcAvg = (reviews, id) => {
+  const r = reviews.filter((v) => v.hotelId === id);
+  return r.length ? r.reduce((s, v) => s + v.ratings, 0) / r.length : 0;
+};
+
+export default function RecentlyViewed() {
+  const [hotels, setHotels] = useState([]);
+  const [reviews, setReviews] = useState([]);
+  const [isRecommended, setIsRecommended] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const prefersReducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [hotelsRes, reviewsRes] = await Promise.all([getAllHotels(), getReviews()]);
+        const allHotels = hotelsRes?.hotels ?? [];
+        const allReviews = reviewsRes?.reviews ?? [];
+        setReviews(allReviews);
+
+        const viewedIds = getRecentlyViewed();
+        const byId = Object.fromEntries(allHotels.map((h) => [h._id, h]));
+        const viewed = viewedIds.map((id) => byId[id]).filter(Boolean);
+
+        if (viewed.length > 0) {
+          setHotels(viewed);
+          setIsRecommended(false);
+        } else {
+          const recommended = [...allHotels]
+            .map((h) => ({ ...h, avg: calcAvg(allReviews, h._id) }))
+            .sort((a, b) => b.avg - a.avg)
+            .slice(0, 4);
+          setHotels(recommended);
+          setIsRecommended(true);
+        }
+      } catch (e) {
+        console.error("Failed to load recently viewed hotels:", e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  if (!loading && hotels.length === 0) return null;
+
+  return (
+    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <div className="text-center mb-10">
+        <h2 className="font-serif text-4xl md:text-5xl text-ink mb-4">
+          {isRecommended ? "Recommended For You" : "Recently Viewed"}
+        </h2>
+        <p className="text-lg text-muted max-w-2xl mx-auto">
+          {isRecommended
+            ? "Popular stays picked based on guest ratings"
+            : "Pick up where you left off"}
+        </p>
+      </div>
+
+      {loading ? (
+        <HotelGridSkeleton count={4} />
+      ) : (
+        <motion.div
+          initial={prefersReducedMotion ? false : "hidden"}
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={stagger}
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6"
+        >
+          {hotels.map((hotel) => (
+            <motion.div key={hotel._id} variants={fadeUp}>
+              <Hotel hotel={hotel} averageRating={calcAvg(reviews, hotel._id)} />
+            </motion.div>
+          ))}
+        </motion.div>
+      )}
+    </section>
+  );
+}

--- a/components/Testimonials.jsx
+++ b/components/Testimonials.jsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { Star, Quote } from "lucide-react";
+import { getAllHotels, getReviews } from "@/app/action";
+import Skeleton from "./skeletons/Skeleton";
+import { fadeUp, stagger } from "@/lib/motion";
+
+export default function Testimonials() {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const prefersReducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [hotelsRes, reviewsRes] = await Promise.all([getAllHotels(), getReviews()]);
+        const hotels = hotelsRes?.hotels ?? [];
+        const reviews = reviewsRes?.reviews ?? [];
+        const hotelById = Object.fromEntries(hotels.map((h) => [h._id, h]));
+
+        const seenHotels = new Set();
+        const top = [...reviews]
+          .filter((r) => r.ratings >= 4 && r.review)
+          .sort((a, b) => b.ratings - a.ratings)
+          .filter((r) => {
+            if (seenHotels.has(r.hotelId)) return false;
+            seenHotels.add(r.hotelId);
+            return true;
+          })
+          .slice(0, 6)
+          .map((r) => ({ ...r, hotel: hotelById[r.hotelId] }));
+
+        setItems(top);
+      } catch (e) {
+        console.error("Failed to load testimonials:", e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  if (!loading && items.length === 0) return null;
+
+  return (
+    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <div className="text-center mb-10">
+        <h2 className="font-serif text-4xl md:text-5xl text-ink mb-4">
+          What Our Guests Say
+        </h2>
+        <p className="text-lg text-muted max-w-2xl mx-auto">
+          Real reviews from travelers who found their perfect stay
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="bg-surface rounded-xl border border-hairline p-6 space-y-3">
+              <Skeleton className="h-4 w-24 rounded" />
+              <Skeleton className="h-16 w-full rounded" />
+              <Skeleton className="h-4 w-32 rounded" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <motion.div
+          initial={prefersReducedMotion ? false : "hidden"}
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={stagger}
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+        >
+          {items.map((item) => (
+            <motion.div
+              key={item._id}
+              variants={fadeUp}
+              className="bg-surface rounded-xl border border-hairline p-6 hover:shadow-luxe transition-shadow duration-300"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex gap-0.5">
+                  {[...Array(5)].map((_, i) => (
+                    <Star
+                      key={i}
+                      className={`w-4 h-4 ${
+                        i < item.ratings ? "text-brass-dark fill-current" : "text-hairline"
+                      }`}
+                    />
+                  ))}
+                </div>
+                <Quote className="w-6 h-6 text-hairline" aria-hidden="true" />
+              </div>
+              <p className="text-ink text-sm leading-relaxed line-clamp-4 mb-4">
+                {item.review}
+              </p>
+              <div className="flex items-center justify-between text-sm">
+                <span className="font-semibold text-ink">{item.userName}</span>
+                {item.hotel && (
+                  <span className="text-muted line-clamp-1">{item.hotel.title}</span>
+                )}
+              </div>
+            </motion.div>
+          ))}
+        </motion.div>
+      )}
+    </section>
+  );
+}

--- a/components/TrackRecentlyViewed.jsx
+++ b/components/TrackRecentlyViewed.jsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+import { addRecentlyViewed } from "@/lib/recentlyViewed";
+
+export default function TrackRecentlyViewed({ hotelId }) {
+  useEffect(() => {
+    if (hotelId) addRecentlyViewed(hotelId);
+  }, [hotelId]);
+
+  return null;
+}

--- a/components/WhyBookWithUs.jsx
+++ b/components/WhyBookWithUs.jsx
@@ -1,0 +1,54 @@
+import { ShieldCheck, RefreshCw, Headset, BadgePercent } from "lucide-react";
+
+const REASONS = [
+  {
+    icon: ShieldCheck,
+    title: "Secure Payments",
+    text: "Your transactions are protected with industry-standard encryption.",
+  },
+  {
+    icon: RefreshCw,
+    title: "Free Cancellation",
+    text: "Plans change - cancel most bookings free up to 48 hours before check-in.",
+  },
+  {
+    icon: Headset,
+    title: "24/7 Support",
+    text: "Our team is here around the clock for any questions or issues.",
+  },
+  {
+    icon: BadgePercent,
+    title: "Best Price Guarantee",
+    text: "Find a lower price elsewhere? We'll match it, no questions asked.",
+  },
+];
+
+export default function WhyBookWithUs() {
+  return (
+    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <div className="text-center mb-10">
+        <h2 className="font-serif text-4xl md:text-5xl text-ink mb-4">
+          Why Book With Us
+        </h2>
+        <p className="text-lg text-muted max-w-2xl mx-auto">
+          Booking your next stay should feel effortless and secure
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        {REASONS.map(({ icon: Icon, title, text }) => (
+          <div
+            key={title}
+            className="bg-surface rounded-xl border border-hairline p-6 text-center hover:shadow-luxe transition-shadow duration-300"
+          >
+            <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-surface-alt flex items-center justify-center">
+              <Icon className="w-6 h-6 text-brass-dark" aria-hidden="true" />
+            </div>
+            <h3 className="text-lg font-semibold text-ink mb-2">{title}</h3>
+            <p className="text-sm text-muted">{text}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/lib/recentlyViewed.js
+++ b/lib/recentlyViewed.js
@@ -1,0 +1,20 @@
+const KEY = "recentlyViewedHotels";
+const MAX = 8;
+
+export function getRecentlyViewed() {
+  try {
+    return JSON.parse(localStorage.getItem(KEY)) ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export function addRecentlyViewed(hotelId) {
+  try {
+    const ids = getRecentlyViewed().filter((id) => id !== hotelId);
+    ids.unshift(hotelId);
+    localStorage.setItem(KEY, JSON.stringify(ids.slice(0, MAX)));
+  } catch {
+    // localStorage unavailable (private mode, SSR edge case) - skip silently
+  }
+}


### PR DESCRIPTION
## Summary
- **Testimonials** - top guest reviews grid, one per hotel, from seeded review data
- **Popular Destinations** - hotels grouped by location, top 8 by count, click filters the Find Your Stay listing to that city
- **Recently Viewed** - localStorage-tracked hotel visits, falls back to a "Recommended For You" top-rated grid when history is empty
- **Why Book With Us** - static trust bar (secure payments, free cancellation, 24/7 support, best price guarantee)
- **How It Works** - static 3-step search/book/stay section
- **FAQ** - accordion built on native `<details>`/`<summary>`, zero JS

## Test plan
- [x] `next build` exits 0, no new warnings
- [x] Verified via curl against a prod server that all 6 section headings render on `/`

https://claude.ai/code/session_01PqryYY1A7svenYsgfoA9qw