### PR TITLE
feat: hotel typeahead in navbar + hero search, drop dead date fields

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -52,12 +52,26 @@ export default async function Home() {
   const heroImage = pickHeroImage(hotels);
   const destinations = topDestinations(hotels);
   const categories = [...new Set(hotels.map((h) => h.category))];
+  // Slim list for the hero search typeahead - only the fields it renders.
+  const heroHotels = hotels.map((h) => ({
+    _id: h._id,
+    title: h.title,
+    location: h.location,
+    category: h.category,
+    rent: h.rent,
+    image: h.images?.[0] || null,
+  }));
 
   return (
     <>
       <AnnounceBar />
       <Navbar />
-      <Hero image={heroImage} destinations={destinations} categories={categories} />
+      <Hero
+        image={heroImage}
+        destinations={destinations}
+        categories={categories}
+        hotels={heroHotels}
+      />
       <HotelListing initialData={initialListing} initialReviews={reviews} />
       <HotelsCategory hotels={hotels} />
       <PopularDestinations hotels={hotels} />

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { motion, useScroll, useTransform, useReducedMotion } from "framer-motion";
 import { Search, MapPin, Users } from "lucide-react";
-import DatePicker from "react-datepicker";
-import "react-datepicker/dist/react-datepicker.css";
 
 const FALLBACK_IMAGE =
   "https://images.unsplash.com/photo-1611892440504-42a792e24d32?auto=format&fit=crop&w=2000&q=80";
@@ -24,11 +22,9 @@ const CATEGORY_LABELS = {
   ski: "Ski",
 };
 
-export default function Hero({ image, destinations = [], categories = [] }) {
+export default function Hero({ image, destinations = [], categories = [], hotels = [] }) {
   const router = useRouter();
   const [location, setLocation] = useState("");
-  const [checkIn, setCheckIn] = useState(null);
-  const [checkOut, setCheckOut] = useState(null);
   const [guestCount, setGuestCount] = useState(1);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
@@ -64,8 +60,7 @@ export default function Hero({ image, destinations = [], categories = [] }) {
   }, []);
 
   // Close the suggestions dropdown on outside click. Uses `click` (not
-  // `mousedown`) so clicking the search button still submits the form -
-  // a mousedown close mid-interaction was swallowing the submit.
+  // `mousedown`) so clicking the search button still submits the form.
   useEffect(() => {
     const onClick = (e) => {
       if (locationBoxRef.current && !locationBoxRef.current.contains(e.target)) {
@@ -80,8 +75,6 @@ export default function Hero({ image, destinations = [], categories = [] }) {
     const params = new URLSearchParams();
     if (loc) params.set("location", loc);
     if (guestCount > 1) params.set("guests", String(guestCount));
-    if (checkIn) params.set("checkin", checkIn.toISOString().slice(0, 10));
-    if (checkOut) params.set("checkout", checkOut.toISOString().slice(0, 10));
     router.push(`/search?${params.toString()}`);
   };
 
@@ -90,10 +83,23 @@ export default function Hero({ image, destinations = [], categories = [] }) {
     goToSearch(location.trim());
   };
 
-  const filteredDestinations = location.trim()
-    ? destinations.filter((d) =>
-        d.toLowerCase().includes(location.trim().toLowerCase())
+  const query = location.trim().toLowerCase();
+
+  // Typeahead: when the user is typing, match real hotels.
+  const hotelMatches = useMemo(() => {
+    if (!query) return [];
+    return hotels
+      .filter(
+        (h) =>
+          h.title?.toLowerCase().includes(query) ||
+          h.location?.toLowerCase().includes(query) ||
+          h.category?.toLowerCase().includes(query)
       )
+      .slice(0, 5);
+  }, [query, hotels]);
+
+  const filteredDestinations = query
+    ? destinations.filter((d) => d.toLowerCase().includes(query))
     : destinations;
 
   return (
@@ -130,9 +136,9 @@ export default function Hero({ image, destinations = [], categories = [] }) {
 
         <form
           onSubmit={handleSearch}
-          className="w-full max-w-4xl bg-surface/95 backdrop-blur-md rounded-2xl border border-hairline shadow-luxe p-4 sm:p-5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3"
+          className="w-full max-w-3xl bg-surface/95 backdrop-blur-md rounded-2xl border border-hairline shadow-luxe p-3 sm:p-4 flex flex-col sm:flex-row gap-3"
         >
-          <div className="text-left relative" ref={locationBoxRef}>
+          <div className="text-left relative flex-1" ref={locationBoxRef}>
             <div className="flex items-center gap-2 border border-hairline rounded-lg px-3 py-2.5 bg-surface h-11">
               <MapPin className="w-4 h-4 text-muted flex-shrink-0" aria-hidden="true" />
               <input
@@ -148,114 +154,140 @@ export default function Hero({ image, destinations = [], categories = [] }) {
               />
             </div>
 
-            {dropdownOpen && (destinations.length > 0 || categories.length > 0) && (
-              <div className="absolute z-20 left-0 right-0 mt-2 bg-surface border border-hairline rounded-xl shadow-luxe p-3 text-left max-h-80 overflow-y-auto">
-                {filteredDestinations.length > 0 && (
+            {dropdownOpen && (
+              <div className="absolute z-20 left-0 right-0 mt-2 bg-surface border border-hairline rounded-xl shadow-luxe overflow-hidden text-left max-h-96 overflow-y-auto">
+                {query ? (
                   <>
-                    <p className="text-xs font-semibold text-muted uppercase tracking-wide px-2 mb-1">
-                      Popular destinations
-                    </p>
-                    <ul className="mb-2">
-                      {filteredDestinations.slice(0, 6).map((dest) => (
-                        <li key={dest}>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setLocation(dest);
-                              setDropdownOpen(false);
-                              goToSearch(dest);
-                            }}
-                            className="w-full flex items-center gap-2 px-2 py-2 rounded-lg text-sm text-ink hover:bg-surface-alt transition-colors"
-                          >
-                            <MapPin className="w-4 h-4 text-brass-dark flex-shrink-0" />
-                            {dest}
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
+                    {hotelMatches.length > 0 ? (
+                      <ul>
+                        {hotelMatches.map((h) => (
+                          <li key={h._id}>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setDropdownOpen(false);
+                                router.push(`/details/${h._id}`);
+                              }}
+                              className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-surface-alt transition-colors text-left"
+                            >
+                              <span className="relative w-12 h-12 rounded-lg overflow-hidden bg-surface-alt flex-shrink-0">
+                                <Image
+                                  src={h.image || "https://placehold.co/96x96"}
+                                  alt={h.title}
+                                  fill
+                                  sizes="48px"
+                                  className="object-cover"
+                                />
+                              </span>
+                              <span className="min-w-0 flex-1">
+                                <span className="block text-sm font-medium text-ink truncate">
+                                  {h.title}
+                                </span>
+                                <span className="block text-xs text-muted truncate">
+                                  {h.location}
+                                  {h.category ? ` · ${CATEGORY_LABELS[h.category] || h.category}` : ""}
+                                </span>
+                              </span>
+                              <span className="text-sm font-semibold text-ink flex-shrink-0">
+                                ${h.rent}
+                              </span>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="px-3 py-3 text-sm text-muted">No matches for "{location.trim()}"</p>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setDropdownOpen(false);
+                        goToSearch(location.trim());
+                      }}
+                      className="w-full flex items-center gap-2 px-3 py-2.5 border-t border-hairline text-sm text-brass-dark hover:bg-surface-alt transition-colors font-medium"
+                    >
+                      <Search className="w-4 h-4" />
+                      Search all stays for "{location.trim()}"
+                    </button>
                   </>
-                )}
+                ) : (
+                  <div className="p-3">
+                    {filteredDestinations.length > 0 && (
+                      <>
+                        <p className="text-xs font-semibold text-muted uppercase tracking-wide px-2 mb-1">
+                          Popular destinations
+                        </p>
+                        <ul className="mb-2">
+                          {filteredDestinations.slice(0, 6).map((dest) => (
+                            <li key={dest}>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setLocation(dest);
+                                  setDropdownOpen(false);
+                                  goToSearch(dest);
+                                }}
+                                className="w-full flex items-center gap-2 px-2 py-2 rounded-lg text-sm text-ink hover:bg-surface-alt transition-colors"
+                              >
+                                <MapPin className="w-4 h-4 text-brass-dark flex-shrink-0" />
+                                {dest}
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      </>
+                    )}
 
-                {categories.length > 0 && (
-                  <>
-                    <p className="text-xs font-semibold text-muted uppercase tracking-wide px-2 mb-1">
-                      Browse by type
-                    </p>
-                    <div className="flex flex-wrap gap-2 px-2 pt-1">
-                      {categories.map((cat) => (
-                        <button
-                          key={cat}
-                          type="button"
-                          onClick={() => {
-                            setDropdownOpen(false);
-                            router.push(`/category/${cat}`);
-                          }}
-                          className="px-3 py-1.5 rounded-full border border-hairline text-xs text-ink hover:bg-surface-alt hover:border-brass transition-colors"
-                        >
-                          {CATEGORY_LABELS[cat] || cat}
-                        </button>
-                      ))}
-                    </div>
-                  </>
+                    {categories.length > 0 && (
+                      <>
+                        <p className="text-xs font-semibold text-muted uppercase tracking-wide px-2 mb-1">
+                          Browse by type
+                        </p>
+                        <div className="flex flex-wrap gap-2 px-2 pt-1">
+                          {categories.map((cat) => (
+                            <button
+                              key={cat}
+                              type="button"
+                              onClick={() => {
+                                setDropdownOpen(false);
+                                router.push(`/category/${cat}`);
+                              }}
+                              className="px-3 py-1.5 rounded-full border border-hairline text-xs text-ink hover:bg-surface-alt hover:border-brass transition-colors"
+                            >
+                              {CATEGORY_LABELS[cat] || cat}
+                            </button>
+                          ))}
+                        </div>
+                      </>
+                    )}
+                  </div>
                 )}
               </div>
             )}
           </div>
 
-          <label className="text-left">
-            <span className="sr-only">Check-in</span>
-            <div className="border border-hairline rounded-lg px-3 bg-surface h-11 flex items-center">
-              <DatePicker
-                selected={checkIn}
-                onChange={setCheckIn}
-                selectsStart
-                startDate={checkIn}
-                endDate={checkOut}
-                minDate={new Date()}
-                placeholderText="Check-in"
-                className="w-full outline-none text-sm bg-transparent text-ink placeholder:text-muted"
+          <label className="text-left sm:w-32">
+            <span className="sr-only">Guests</span>
+            <div className="flex items-center gap-2 border border-hairline rounded-lg px-3 bg-surface h-11">
+              <Users className="w-4 h-4 text-muted flex-shrink-0" aria-hidden="true" />
+              <input
+                type="number"
+                min={1}
+                value={guestCount}
+                onChange={(e) => setGuestCount(Math.max(1, Number(e.target.value) || 1))}
+                className="w-full outline-none text-sm bg-transparent text-ink"
+                aria-label="Guests"
               />
             </div>
           </label>
 
-          <label className="text-left">
-            <span className="sr-only">Check-out</span>
-            <div className="border border-hairline rounded-lg px-3 bg-surface h-11 flex items-center">
-              <DatePicker
-                selected={checkOut}
-                onChange={setCheckOut}
-                selectsEnd
-                startDate={checkIn}
-                endDate={checkOut}
-                minDate={checkIn || new Date()}
-                placeholderText="Check-out"
-                className="w-full outline-none text-sm bg-transparent text-ink placeholder:text-muted"
-              />
-            </div>
-          </label>
-
-          <div className="flex gap-2">
-            <label className="flex-1 text-left">
-              <span className="sr-only">Guests</span>
-              <div className="flex items-center gap-2 border border-hairline rounded-lg px-3 bg-surface h-11">
-                <Users className="w-4 h-4 text-muted flex-shrink-0" aria-hidden="true" />
-                <input
-                  type="number"
-                  min={1}
-                  value={guestCount}
-                  onChange={(e) => setGuestCount(Math.max(1, Number(e.target.value) || 1))}
-                  className="w-full outline-none text-sm bg-transparent text-ink"
-                />
-              </div>
-            </label>
-            <button
-              type="submit"
-              aria-label="Search hotels"
-              className="flex items-center justify-center bg-brass-dark hover:bg-brass text-cream rounded-lg h-11 px-4 transition-colors"
-            >
-              <Search className="w-4 h-4" aria-hidden="true" />
-            </button>
-          </div>
+          <button
+            type="submit"
+            className="flex items-center justify-center gap-2 bg-brass-dark hover:bg-brass text-cream rounded-lg h-11 px-6 transition-colors font-medium"
+          >
+            <Search className="w-4 h-4" aria-hidden="true" />
+            <span className="sm:hidden">Search</span>
+          </button>
         </form>
       </div>
     </section>

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import {
   Search,
   Globe,
@@ -23,6 +23,20 @@ import {
 import SignOutButton from "./SignOutButton";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import { getAllHotels } from "@/app/action";
+
+const CATEGORY_LABELS = {
+  urban: "Urban",
+  beach: "Beach",
+  mountain: "Mountain",
+  luxury: "Luxury",
+  rustic: "Rustic",
+  countryside: "Countryside",
+  lakeside: "Lakeside",
+  desert: "Desert",
+  island: "Island",
+  ski: "Ski",
+};
 
 const Navbar = () => {
   const router = useRouter();
@@ -62,9 +76,53 @@ const Navbar = () => {
   }, [isPopupVisible]);
 
   const [searchValue, setSearchValue] = useState("");
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [hotels, setHotels] = useState([]);
+  const [hotelsReady, setHotelsReady] = useState(false);
+  const hotelsLoaded = useRef(false);
+  const searchRef = useRef(null);
+
+  // Lazily load the hotel list the first time the user engages the search -
+  // avoids fetching on every page just to power the navbar typeahead.
+  const loadHotels = async () => {
+    if (hotelsLoaded.current) return;
+    hotelsLoaded.current = true;
+    try {
+      const res = await getAllHotels();
+      setHotels(res?.hotels ?? []);
+      setHotelsReady(true);
+    } catch (e) {
+      console.error("Failed to load hotels for search:", e);
+      hotelsLoaded.current = false;
+    }
+  };
+
+  const query = searchValue.trim().toLowerCase();
+  const matches = useMemo(() => {
+    if (!query) return [];
+    return hotels
+      .filter(
+        (h) =>
+          h.title?.toLowerCase().includes(query) ||
+          h.location?.toLowerCase().includes(query) ||
+          h.category?.toLowerCase().includes(query)
+      )
+      .slice(0, 6);
+  }, [query, hotels]);
+
+  useEffect(() => {
+    const onClick = (e) => {
+      if (searchRef.current && !searchRef.current.contains(e.target)) {
+        setSearchOpen(false);
+      }
+    };
+    document.addEventListener("click", onClick);
+    return () => document.removeEventListener("click", onClick);
+  }, []);
 
   const submitSearch = () => {
     const q = searchValue.trim();
+    setSearchOpen(false);
     router.push(q ? `/search?location=${encodeURIComponent(q)}` : "/search");
   };
 
@@ -88,19 +146,84 @@ const Navbar = () => {
         </Link>
       </div>
 
-      <div className="row-start-2 col-span-2 border-0 md:border md:border-hairline flex shadow-sm hover:shadow-md transition-all md:rounded-full items-center px-2 mt-2 sm:md:mt-0 bg-surface">
+      <div
+        ref={searchRef}
+        className="row-start-2 col-span-2 relative border-0 md:border md:border-hairline flex shadow-sm hover:shadow-md transition-all md:rounded-full items-center px-2 mt-2 sm:md:mt-0 bg-surface"
+      >
         <div className="grid md:grid-cols-3 lg:grid-cols-7 gap-4 divide-x divide-hairline py-2 md:px-2 flex-grow">
           <input
             type="text"
             placeholder="Search a city or hotel"
             value={searchValue}
             className="px-3 bg-transparent focus:outline-none lg:col-span-3 placeholder:text-sm text-ink font-sans"
-            onChange={(e) => setSearchValue(e.target.value)}
+            onFocus={() => {
+              loadHotels();
+              setSearchOpen(true);
+            }}
+            onChange={(e) => {
+              setSearchValue(e.target.value);
+              setSearchOpen(true);
+            }}
             onKeyDown={(e) => {
               if (e.key === "Enter") submitSearch();
             }}
           />
         </div>
+
+        {searchOpen && query && (
+          <div className="absolute left-0 right-0 top-full mt-2 bg-surface border border-hairline rounded-2xl shadow-luxe overflow-hidden z-50 text-left">
+            {!hotelsReady ? (
+              <p className="px-4 py-3 text-sm text-muted">Searching…</p>
+            ) : matches.length > 0 ? (
+              <ul className="max-h-96 overflow-y-auto">
+                {matches.map((h) => (
+                  <li key={h._id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSearchOpen(false);
+                        router.push(`/details/${h._id}`);
+                      }}
+                      className="w-full flex items-center gap-3 px-4 py-2.5 hover:bg-surface-alt transition-colors text-left"
+                    >
+                      <span className="relative w-12 h-12 rounded-lg overflow-hidden bg-surface-alt flex-shrink-0">
+                        <Image
+                          src={h.images?.[0] || "https://placehold.co/96x96"}
+                          alt={h.title}
+                          fill
+                          sizes="48px"
+                          className="object-cover"
+                        />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-sm font-medium text-ink truncate">
+                          {h.title}
+                        </span>
+                        <span className="block text-xs text-muted truncate">
+                          {h.location}
+                          {h.category ? ` · ${CATEGORY_LABELS[h.category] || h.category}` : ""}
+                        </span>
+                      </span>
+                      <span className="text-sm font-semibold text-ink flex-shrink-0">
+                        ${h.rent}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="px-4 py-3 text-sm text-muted">No matches for "{searchValue.trim()}"</p>
+            )}
+            <button
+              type="button"
+              onClick={submitSearch}
+              className="w-full flex items-center gap-2 px-4 py-2.5 border-t border-hairline text-sm text-brass-dark hover:bg-surface-alt transition-colors font-medium"
+            >
+              <Search className="w-4 h-4" />
+              Search all stays for "{searchValue.trim()}"
+            </button>
+          </div>
+        )}
 
         <button
           type="button"


### PR DESCRIPTION
## Navbar search — live typeahead
Typing shows a dropdown of matching hotels (thumbnail, title, location · category, price). Clicking a result opens that hotel's details page. Enter / the search icon / "Search all stays for X" still navigate to `/search?location=…`.

The hotel list is **lazy-loaded on first focus**, so it costs nothing on pages where nobody uses search. A "Searching…" state shows while it loads.

## Hero search — same typeahead + simpler
- Same hotel typeahead when the user types (fed by a slim `hotels` prop from the server — no client fetch). Before typing, it still shows popular destinations + category chips.
- **Removed Check-in / Check-out.** They were decorative — nothing wires dates into results (there's no availability system), so clicking a suggestion ignored them. Kept **Guests**, which actually filters by capacity via `?guests=`.

## Test plan (verified against dev server)
- [x] Navbar: type "dubai" → "Dubai Luxury Hotel · Luxury · $195" → click → `/details/<id>`
- [x] Navbar: lazy fetch on focus; "Searching…" while loading; "Search all stays for X" → `/search`
- [x] Hero: type "beach" → 5 hotel matches with thumbnails/price
- [x] Hero: no Check-in/Check-out; Guests present and functional
- [x] Homepage + `/search` compile clean (200)

_Note: skipped the standalone `next build` this round because a live `next dev` shares `.next` and a concurrent build corrupts it; verified via the running dev server instead._

https://claude.ai/code/session_01PqryYY1A7svenYsgfoA9qw