### PR TITLE
feat: Airbnb-style segmented hero search with real filters

### DIFF
--- a/app/action/index.js
+++ b/app/action/index.js
@@ -95,6 +95,94 @@ export async function getHotels(page = 1, pageSize = 8, searchQuery = '', minGue
     }
 }
 
+// Rich filtered search used by the /search page. One aggregation handles
+// location, guests, category, price range, amenities, and min-rating (which
+// needs a review lookup) plus pagination. getHotels stays light for the
+// homepage browse listing.
+export async function searchHotels({
+    location = '',
+    guests = 0,
+    category = '',
+    minPrice = 0,
+    maxPrice = 0,
+    amenities = [],
+    minRating = 0,
+    page = 1,
+    pageSize = 12,
+} = {}) {
+    try {
+        await dbConnect();
+
+        const match = {};
+        if (location) {
+            match.$or = [
+                { title: { $regex: location, $options: 'i' } },
+                { location: { $regex: location, $options: 'i' } },
+            ];
+        }
+        if (guests > 0) match.guestCapacity = { $gte: guests };
+        if (category) match.category = category;
+        if (minPrice > 0 || maxPrice > 0) {
+            match.rent = {};
+            if (minPrice > 0) match.rent.$gte = minPrice;
+            if (maxPrice > 0) match.rent.$lte = maxPrice;
+        }
+        if (amenities.length > 0) match.amenities = { $all: amenities };
+
+        const pipeline = [{ $match: match }];
+
+        // Only pay for the review join when a rating filter is active.
+        if (minRating > 0) {
+            pipeline.push(
+                {
+                    $lookup: {
+                        from: 'reviews',
+                        localField: '_id',
+                        foreignField: 'hotelId',
+                        as: 'reviewDocs',
+                    },
+                },
+                {
+                    $addFields: {
+                        avgRating: {
+                            $cond: [
+                                { $gt: [{ $size: '$reviewDocs' }, 0] },
+                                { $avg: '$reviewDocs.ratings' },
+                                0,
+                            ],
+                        },
+                    },
+                },
+                { $match: { avgRating: { $gte: minRating } } },
+                { $project: { reviewDocs: 0 } },
+            );
+        }
+
+        const skip = (page - 1) * pageSize;
+        pipeline.push({
+            $facet: {
+                data: [{ $sort: { createdAt: -1 } }, { $skip: skip }, { $limit: pageSize }],
+                meta: [{ $count: 'total' }],
+            },
+        });
+
+        const [result] = await Hotel.aggregate(pipeline);
+        const hotels = result?.data ?? [];
+        const total = result?.meta?.[0]?.total ?? 0;
+
+        return toPlain({
+            hotels,
+            total,
+            page,
+            pageSize,
+            totalPages: Math.ceil(total / pageSize),
+        });
+    } catch (error) {
+        console.error('Failed to search hotels:', error);
+        throw error;
+    }
+}
+
 export async function getAllHotels(category = null) {
     try {
         await dbConnect();

--- a/app/page.js
+++ b/app/page.js
@@ -61,6 +61,14 @@ export default async function Home() {
     rent: h.rent,
     image: h.images?.[0] || null,
   }));
+  const amenityOptions = [
+    ...new Set(hotels.flatMap((h) => h.amenities ?? [])),
+  ].sort();
+  const rents = hotels.map((h) => h.rent).filter((n) => typeof n === "number");
+  const priceBounds = {
+    min: rents.length ? Math.floor(Math.min(...rents)) : 0,
+    max: rents.length ? Math.ceil(Math.max(...rents)) : 1000,
+  };
 
   return (
     <>
@@ -71,6 +79,8 @@ export default async function Home() {
         destinations={destinations}
         categories={categories}
         hotels={heroHotels}
+        amenityOptions={amenityOptions}
+        priceBounds={priceBounds}
       />
       <HotelListing initialData={initialListing} initialReviews={reviews} />
       <HotelsCategory hotels={hotels} />

--- a/app/search/page.js
+++ b/app/search/page.js
@@ -1,37 +1,55 @@
 /* eslint-disable react/no-unescaped-entities */
 import Link from "next/link";
-import { Search as SearchIcon, ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react";
-import { getHotels, getReviews } from "@/app/action";
+import { Search as SearchIcon, ArrowLeft, ChevronLeft, ChevronRight, X } from "lucide-react";
+import { searchHotels, getReviews } from "@/app/action";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import Hotel from "@/components/Hotel";
 
 const PAGE_SIZE = 12;
 
+const CATEGORY_LABELS = {
+  urban: "Urban", beach: "Beach", mountain: "Mountain", luxury: "Luxury",
+  rustic: "Rustic", countryside: "Countryside", lakeside: "Lakeside",
+  desert: "Desert", island: "Island", ski: "Ski",
+};
+
 export function generateMetadata({ searchParams }) {
   const location = searchParams?.location?.trim();
-  return {
-    title: location ? `Stays in ${location}` : "Search stays",
-  };
+  return { title: location ? `Stays in ${location}` : "Search stays" };
 }
 
-const buildHref = (params, page) => {
+// Normalize raw searchParams into a clean filter object.
+const parseFilters = (sp = {}) => ({
+  location: sp.location?.trim() || "",
+  guests: parseInt(sp.guests || "0", 10) || 0,
+  category: sp.category || "",
+  minPrice: parseInt(sp.minPrice || "0", 10) || 0,
+  maxPrice: parseInt(sp.maxPrice || "0", 10) || 0,
+  minRating: parseFloat(sp.minRating || "0") || 0,
+  amenities: sp.amenities ? sp.amenities.split(",").filter(Boolean) : [],
+});
+
+// Build a /search href from a filter object (+ page), omitting empties.
+const hrefFor = (f, page = 1) => {
   const q = new URLSearchParams();
-  if (params.location) q.set("location", params.location);
-  if (params.checkin) q.set("checkin", params.checkin);
-  if (params.checkout) q.set("checkout", params.checkout);
-  if (params.guests) q.set("guests", params.guests);
-  q.set("page", String(page));
+  if (f.location) q.set("location", f.location);
+  if (f.guests) q.set("guests", String(f.guests));
+  if (f.category) q.set("category", f.category);
+  if (f.minPrice) q.set("minPrice", String(f.minPrice));
+  if (f.maxPrice) q.set("maxPrice", String(f.maxPrice));
+  if (f.minRating) q.set("minRating", String(f.minRating));
+  if (f.amenities.length) q.set("amenities", f.amenities.join(","));
+  if (page > 1) q.set("page", String(page));
   return `/search?${q.toString()}`;
 };
 
 const SearchPage = async ({ searchParams }) => {
-  const location = searchParams?.location?.trim() || "";
-  const guests = parseInt(searchParams?.guests || "0", 10) || 0;
+  const f = parseFilters(searchParams);
   const page = Math.max(1, parseInt(searchParams?.page || "1", 10) || 1);
 
   const [data, reviewsRes] = await Promise.all([
-    getHotels(page, PAGE_SIZE, location, guests),
+    searchHotels({ ...f, page, pageSize: PAGE_SIZE }),
     getReviews(),
   ]);
 
@@ -40,26 +58,53 @@ const SearchPage = async ({ searchParams }) => {
   const totalPages = data?.totalPages ?? 1;
   const reviews = reviewsRes?.reviews ?? [];
 
+  // Active-filter chips: each links back to /search with that filter removed.
+  const chips = [];
+  if (f.location) chips.push({ label: `"${f.location}"`, remove: { ...f, location: "" } });
+  if (f.category) chips.push({ label: CATEGORY_LABELS[f.category] || f.category, remove: { ...f, category: "" } });
+  if (f.guests) chips.push({ label: `${f.guests}+ guests`, remove: { ...f, guests: 0 } });
+  if (f.minPrice || f.maxPrice)
+    chips.push({
+      label: `$${f.minPrice || 0}–$${f.maxPrice || "∞"}`,
+      remove: { ...f, minPrice: 0, maxPrice: 0 },
+    });
+  if (f.minRating) chips.push({ label: `${f.minRating}+ ★`, remove: { ...f, minRating: 0 } });
+  f.amenities.forEach((a) =>
+    chips.push({ label: a, remove: { ...f, amenities: f.amenities.filter((x) => x !== a) } })
+  );
+
   return (
     <div className="min-h-screen flex flex-col bg-cream">
       <Navbar />
       <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 flex-grow">
-        <div className="mb-8">
+        <div className="mb-6">
           <h1 className="font-serif text-3xl sm:text-4xl text-ink">
             {total} {total === 1 ? "stay" : "stays"}
-            {location ? (
-              <>
-                {" "}for "<span className="text-brass-dark">{location}</span>"
-              </>
+            {f.location ? (
+              <> for "<span className="text-brass-dark">{f.location}</span>"</>
             ) : (
               " available"
             )}
           </h1>
-          <p className="text-muted mt-2">
-            {guests > 0 && `For ${guests} ${guests === 1 ? "guest" : "guests"} · `}
-            Browse and book your next stay.
-          </p>
         </div>
+
+        {chips.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 mb-8">
+            {chips.map((c, i) => (
+              <Link
+                key={i}
+                href={hrefFor(c.remove)}
+                className="inline-flex items-center gap-1.5 pl-3 pr-2 py-1.5 rounded-full border border-hairline bg-surface text-sm text-ink hover:bg-surface-alt transition-colors"
+              >
+                {c.label}
+                <X className="w-3.5 h-3.5 text-muted" />
+              </Link>
+            ))}
+            <Link href="/search" className="text-sm text-brass-dark hover:underline ml-1">
+              Clear all
+            </Link>
+          </div>
+        )}
 
         {hotels.length === 0 ? (
           <div className="text-center py-16">
@@ -67,10 +112,7 @@ const SearchPage = async ({ searchParams }) => {
               <SearchIcon className="w-9 h-9 text-muted" />
             </div>
             <h2 className="font-serif text-2xl text-ink mb-2">No stays found</h2>
-            <p className="text-muted mb-6">
-              We couldn't find anything matching {location ? `"${location}"` : "your search"}.
-              Try a different destination.
-            </p>
+            <p className="text-muted mb-6">Try removing a filter or searching a different destination.</p>
             <Link
               href="/"
               className="inline-flex items-center px-6 py-3 bg-brass-dark text-cream rounded-lg hover:bg-brass transition-colors font-medium"
@@ -94,17 +136,13 @@ const SearchPage = async ({ searchParams }) => {
 
             {totalPages > 1 && (
               <div className="mt-10 flex justify-center items-center gap-2">
-                <PageLink
-                  href={buildHref({ location, guests }, page - 1)}
-                  disabled={page <= 1}
-                  aria={"Previous page"}
-                >
+                <PageLink href={hrefFor(f, page - 1)} disabled={page <= 1} aria="Previous page">
                   <ChevronLeft className="w-4 h-4" />
                 </PageLink>
                 {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
                   <Link
                     key={p}
-                    href={buildHref({ location, guests }, p)}
+                    href={hrefFor(f, p)}
                     className={`py-2 px-3.5 rounded-lg border text-sm ${
                       p === page
                         ? "bg-brass-dark text-cream border-brass-dark"
@@ -114,11 +152,7 @@ const SearchPage = async ({ searchParams }) => {
                     {p}
                   </Link>
                 ))}
-                <PageLink
-                  href={buildHref({ location, guests }, page + 1)}
-                  disabled={page >= totalPages}
-                  aria={"Next page"}
-                >
+                <PageLink href={hrefFor(f, page + 1)} disabled={page >= totalPages} aria="Next page">
                   <ChevronRight className="w-4 h-4" />
                 </PageLink>
               </div>
@@ -133,18 +167,11 @@ const SearchPage = async ({ searchParams }) => {
 
 const PageLink = ({ href, disabled, aria, children }) =>
   disabled ? (
-    <span
-      aria-label={aria}
-      className="flex items-center py-2 px-3 rounded-lg border border-hairline bg-surface text-muted opacity-50 pointer-events-none"
-    >
+    <span aria-label={aria} className="flex items-center py-2 px-3 rounded-lg border border-hairline bg-surface text-muted opacity-50 pointer-events-none">
       {children}
     </span>
   ) : (
-    <Link
-      href={href}
-      aria-label={aria}
-      className="flex items-center py-2 px-3 rounded-lg border border-hairline bg-surface text-muted hover:bg-surface-alt hover:text-ink"
-    >
+    <Link href={href} aria-label={aria} className="flex items-center py-2 px-3 rounded-lg border border-hairline bg-surface text-muted hover:bg-surface-alt hover:text-ink">
       {children}
     </Link>
   );

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -4,7 +4,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { motion, useScroll, useTransform, useReducedMotion } from "framer-motion";
-import { Search, MapPin, Users } from "lucide-react";
+import { Search, MapPin, Users, Star, Minus, Plus, SlidersHorizontal, ChevronDown } from "lucide-react";
 
 const FALLBACK_IMAGE =
   "https://images.unsplash.com/photo-1611892440504-42a792e24d32?auto=format&fit=crop&w=2000&q=80";
@@ -22,14 +22,38 @@ const CATEGORY_LABELS = {
   ski: "Ski",
 };
 
-export default function Hero({ image, destinations = [], categories = [], hotels = [] }) {
+const RATING_OPTIONS = [
+  { label: "Any", value: 0 },
+  { label: "3+", value: 3 },
+  { label: "4+", value: 4 },
+  { label: "4.5+", value: 4.5 },
+];
+
+export default function Hero({
+  image,
+  destinations = [],
+  categories = [],
+  hotels = [],
+  amenityOptions = [],
+  priceBounds = { min: 0, max: 1000 },
+}) {
   const router = useRouter();
+
+  // Filter state
   const [location, setLocation] = useState("");
-  const [guestCount, setGuestCount] = useState(1);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [category, setCategory] = useState("");
+  const [guests, setGuests] = useState(1);
+  const [minPrice, setMinPrice] = useState("");
+  const [maxPrice, setMaxPrice] = useState("");
+  const [minRating, setMinRating] = useState(0);
+  const [amenities, setAmenities] = useState([]);
+
+  // Which segment popover is open: 'where' | 'type' | 'guests' | 'price' | 'filters' | null
+  const [active, setActive] = useState(null);
 
   const heroRef = useRef(null);
-  const locationBoxRef = useRef(null);
+  const barRef = useRef(null);
+  const inputRef = useRef(null);
   const [chromeH, setChromeH] = useState(0);
 
   const prefersReducedMotion = useReducedMotion();
@@ -39,9 +63,8 @@ export default function Hero({ image, destinations = [], categories = [], hotels
   });
   const parallaxY = useTransform(scrollYProgress, [0, 1], ["0%", "20%"]);
 
-  // Height = viewport minus the announce bar + navbar above it, so together
-  // they read as exactly one screen. Recomputes when the announce bar is
-  // dismissed (its removal is a body DOM mutation) or on resize.
+  // Height = viewport minus the announce bar + navbar, so together they read
+  // as exactly one screen. Recomputes on announce dismiss / resize.
   useLayoutEffect(() => {
     const compute = () => {
       const nav = document.querySelector("nav");
@@ -59,33 +82,33 @@ export default function Hero({ image, destinations = [], categories = [], hotels
     };
   }, []);
 
-  // Close the suggestions dropdown on outside click. Uses `click` (not
-  // `mousedown`) so clicking the search button still submits the form.
+  // Close any open segment on outside click.
   useEffect(() => {
     const onClick = (e) => {
-      if (locationBoxRef.current && !locationBoxRef.current.contains(e.target)) {
-        setDropdownOpen(false);
-      }
+      if (barRef.current && !barRef.current.contains(e.target)) setActive(null);
     };
     document.addEventListener("click", onClick);
     return () => document.removeEventListener("click", onClick);
   }, []);
 
-  const goToSearch = (loc) => {
+  const goToSearch = (loc = location) => {
     const params = new URLSearchParams();
-    if (loc) params.set("location", loc);
-    if (guestCount > 1) params.set("guests", String(guestCount));
+    if (loc.trim()) params.set("location", loc.trim());
+    if (category) params.set("category", category);
+    if (guests > 1) params.set("guests", String(guests));
+    if (minPrice) params.set("minPrice", String(minPrice));
+    if (maxPrice) params.set("maxPrice", String(maxPrice));
+    if (minRating > 0) params.set("minRating", String(minRating));
+    if (amenities.length) params.set("amenities", amenities.join(","));
     router.push(`/search?${params.toString()}`);
   };
 
   const handleSearch = (e) => {
     e.preventDefault();
-    goToSearch(location.trim());
+    goToSearch();
   };
 
   const query = location.trim().toLowerCase();
-
-  // Typeahead: when the user is typing, match real hotels.
   const hotelMatches = useMemo(() => {
     if (!query) return [];
     return hotels
@@ -97,34 +120,50 @@ export default function Hero({ image, destinations = [], categories = [], hotels
       )
       .slice(0, 5);
   }, [query, hotels]);
-
   const filteredDestinations = query
     ? destinations.filter((d) => d.toLowerCase().includes(query))
     : destinations;
+
+  const toggleAmenity = (a) =>
+    setAmenities((prev) => (prev.includes(a) ? prev.filter((x) => x !== a) : [...prev, a]));
+
+  const filterCount = (minRating > 0 ? 1 : 0) + amenities.length;
+  const priceLabel =
+    minPrice || maxPrice
+      ? `$${minPrice || priceBounds.min}–$${maxPrice || priceBounds.max}`
+      : "Any price";
+
+  const segment = (key, label, value, extra = "") => (
+    <button
+      type="button"
+      onClick={() => setActive((a) => (a === key ? null : key))}
+      className={`text-left px-4 py-2 rounded-full transition-colors hover:bg-surface-alt ${
+        active === key ? "bg-surface-alt" : ""
+      } ${extra}`}
+    >
+      <span className="block text-[10px] uppercase tracking-wide text-muted font-semibold">
+        {label}
+      </span>
+      <span className="flex items-center gap-1 text-sm text-ink truncate">
+        {value}
+        <ChevronDown className="w-3 h-3 text-muted flex-shrink-0" />
+      </span>
+    </button>
+  );
 
   return (
     <section
       ref={heroRef}
       style={{ height: chromeH ? `calc(100dvh - ${chromeH}px)` : "100dvh" }}
-      className="relative w-full overflow-hidden min-h-[520px]"
+      className="relative w-full overflow-hidden min-h-[560px]"
     >
       <motion.div
         style={{ y: prefersReducedMotion ? 0 : parallaxY }}
         className="absolute inset-x-0 -top-[10%] h-[120%]"
       >
-        <Image
-          src={image || FALLBACK_IMAGE}
-          alt="Featured hotel"
-          fill
-          priority
-          sizes="100vw"
-          className="object-cover"
-        />
+        <Image src={image || FALLBACK_IMAGE} alt="Featured hotel" fill priority sizes="100vw" className="object-cover" />
       </motion.div>
-      <div
-        className="absolute inset-0 bg-gradient-to-t from-ink via-ink/50 to-ink/10"
-        aria-hidden="true"
-      />
+      <div className="absolute inset-0 bg-gradient-to-t from-ink via-ink/50 to-ink/10" aria-hidden="true" />
 
       <div className="relative z-10 h-full flex flex-col items-center justify-center text-center px-4">
         <h1 className="font-serif text-4xl sm:text-5xl md:text-6xl text-cream mb-4">
@@ -134,160 +173,311 @@ export default function Hero({ image, destinations = [], categories = [], hotels
           Discover handpicked hotels and resorts for your next getaway.
         </p>
 
-        <form
-          onSubmit={handleSearch}
-          className="w-full max-w-3xl bg-surface/95 backdrop-blur-md rounded-2xl border border-hairline shadow-luxe p-3 sm:p-4 flex flex-col sm:flex-row gap-3"
-        >
-          <div className="text-left relative flex-1" ref={locationBoxRef}>
-            <div className="flex items-center gap-2 border border-hairline rounded-lg px-3 py-2.5 bg-surface h-11">
-              <MapPin className="w-4 h-4 text-muted flex-shrink-0" aria-hidden="true" />
-              <input
-                type="text"
-                value={location}
-                onChange={(e) => {
-                  setLocation(e.target.value);
-                  setDropdownOpen(true);
+        <form onSubmit={handleSearch} className="w-full max-w-4xl">
+          <div
+            ref={barRef}
+            className="bg-surface/95 backdrop-blur-md rounded-2xl lg:rounded-full border border-hairline shadow-luxe flex flex-col lg:flex-row lg:items-center p-2 lg:p-1.5 gap-1 lg:gap-0"
+          >
+            {/* WHERE */}
+            <div className="relative flex-1 lg:min-w-0">
+              <div
+                onClick={() => {
+                  setActive("where");
+                  inputRef.current?.focus();
                 }}
-                onFocus={() => setDropdownOpen(true)}
-                placeholder="Search a city or hotel"
-                className="w-full outline-none text-sm bg-transparent text-ink placeholder:text-muted"
-              />
-            </div>
+                className={`px-4 py-1.5 rounded-full cursor-text transition-colors hover:bg-surface-alt ${
+                  active === "where" ? "bg-surface-alt" : ""
+                }`}
+              >
+                <span className="block text-[10px] uppercase tracking-wide text-muted font-semibold">
+                  Where
+                </span>
+                <div className="flex items-center gap-1.5">
+                  <MapPin className="w-3.5 h-3.5 text-muted flex-shrink-0" aria-hidden="true" />
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    value={location}
+                    onChange={(e) => {
+                      setLocation(e.target.value);
+                      setActive("where");
+                    }}
+                    onFocus={() => setActive("where")}
+                    placeholder="Search a city or hotel"
+                    className="w-full outline-none text-sm bg-transparent text-ink placeholder:text-muted"
+                  />
+                </div>
+              </div>
 
-            {dropdownOpen && (
-              <div className="absolute z-20 left-0 right-0 mt-2 bg-surface border border-hairline rounded-xl shadow-luxe overflow-hidden text-left max-h-96 overflow-y-auto">
-                {query ? (
-                  <>
-                    {hotelMatches.length > 0 ? (
-                      <ul>
-                        {hotelMatches.map((h) => (
-                          <li key={h._id}>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                setDropdownOpen(false);
-                                router.push(`/details/${h._id}`);
-                              }}
-                              className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-surface-alt transition-colors text-left"
-                            >
-                              <span className="relative w-12 h-12 rounded-lg overflow-hidden bg-surface-alt flex-shrink-0">
-                                <Image
-                                  src={h.image || "https://placehold.co/96x96"}
-                                  alt={h.title}
-                                  fill
-                                  sizes="48px"
-                                  className="object-cover"
-                                />
-                              </span>
-                              <span className="min-w-0 flex-1">
-                                <span className="block text-sm font-medium text-ink truncate">
-                                  {h.title}
-                                </span>
-                                <span className="block text-xs text-muted truncate">
-                                  {h.location}
-                                  {h.category ? ` · ${CATEGORY_LABELS[h.category] || h.category}` : ""}
-                                </span>
-                              </span>
-                              <span className="text-sm font-semibold text-ink flex-shrink-0">
-                                ${h.rent}
-                              </span>
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="px-3 py-3 text-sm text-muted">No matches for "{location.trim()}"</p>
-                    )}
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setDropdownOpen(false);
-                        goToSearch(location.trim());
-                      }}
-                      className="w-full flex items-center gap-2 px-3 py-2.5 border-t border-hairline text-sm text-brass-dark hover:bg-surface-alt transition-colors font-medium"
-                    >
-                      <Search className="w-4 h-4" />
-                      Search all stays for "{location.trim()}"
-                    </button>
-                  </>
-                ) : (
-                  <div className="p-3">
-                    {filteredDestinations.length > 0 && (
-                      <>
-                        <p className="text-xs font-semibold text-muted uppercase tracking-wide px-2 mb-1">
-                          Popular destinations
-                        </p>
-                        <ul className="mb-2">
-                          {filteredDestinations.slice(0, 6).map((dest) => (
-                            <li key={dest}>
+              {active === "where" && (
+                <div className="absolute z-30 left-0 right-0 lg:w-96 mt-2 bg-surface border border-hairline rounded-xl shadow-luxe overflow-hidden text-left max-h-96 overflow-y-auto">
+                  {query ? (
+                    <>
+                      {hotelMatches.length > 0 ? (
+                        <ul>
+                          {hotelMatches.map((h) => (
+                            <li key={h._id}>
                               <button
                                 type="button"
                                 onClick={() => {
-                                  setLocation(dest);
-                                  setDropdownOpen(false);
-                                  goToSearch(dest);
+                                  setActive(null);
+                                  router.push(`/details/${h._id}`);
                                 }}
-                                className="w-full flex items-center gap-2 px-2 py-2 rounded-lg text-sm text-ink hover:bg-surface-alt transition-colors"
+                                className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-surface-alt transition-colors text-left"
                               >
-                                <MapPin className="w-4 h-4 text-brass-dark flex-shrink-0" />
-                                {dest}
+                                <span className="relative w-12 h-12 rounded-lg overflow-hidden bg-surface-alt flex-shrink-0">
+                                  <Image src={h.image || "https://placehold.co/96x96"} alt={h.title} fill sizes="48px" className="object-cover" />
+                                </span>
+                                <span className="min-w-0 flex-1">
+                                  <span className="block text-sm font-medium text-ink truncate">{h.title}</span>
+                                  <span className="block text-xs text-muted truncate">
+                                    {h.location}
+                                    {h.category ? ` · ${CATEGORY_LABELS[h.category] || h.category}` : ""}
+                                  </span>
+                                </span>
+                                <span className="text-sm font-semibold text-ink flex-shrink-0">${h.rent}</span>
                               </button>
                             </li>
                           ))}
                         </ul>
-                      </>
-                    )}
-
-                    {categories.length > 0 && (
-                      <>
-                        <p className="text-xs font-semibold text-muted uppercase tracking-wide px-2 mb-1">
-                          Browse by type
-                        </p>
-                        <div className="flex flex-wrap gap-2 px-2 pt-1">
-                          {categories.map((cat) => (
-                            <button
-                              key={cat}
-                              type="button"
-                              onClick={() => {
-                                setDropdownOpen(false);
-                                router.push(`/category/${cat}`);
-                              }}
-                              className="px-3 py-1.5 rounded-full border border-hairline text-xs text-ink hover:bg-surface-alt hover:border-brass transition-colors"
-                            >
-                              {CATEGORY_LABELS[cat] || cat}
-                            </button>
-                          ))}
-                        </div>
-                      </>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-
-          <label className="text-left sm:w-32">
-            <span className="sr-only">Guests</span>
-            <div className="flex items-center gap-2 border border-hairline rounded-lg px-3 bg-surface h-11">
-              <Users className="w-4 h-4 text-muted flex-shrink-0" aria-hidden="true" />
-              <input
-                type="number"
-                min={1}
-                value={guestCount}
-                onChange={(e) => setGuestCount(Math.max(1, Number(e.target.value) || 1))}
-                className="w-full outline-none text-sm bg-transparent text-ink"
-                aria-label="Guests"
-              />
+                      ) : (
+                        <p className="px-3 py-3 text-sm text-muted">No matches for &quot;{location.trim()}&quot;</p>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setActive(null);
+                          goToSearch();
+                        }}
+                        className="w-full flex items-center gap-2 px-3 py-2.5 border-t border-hairline text-sm text-brass-dark hover:bg-surface-alt transition-colors font-medium"
+                      >
+                        <Search className="w-4 h-4" />
+                        Search all stays for &quot;{location.trim()}&quot;
+                      </button>
+                    </>
+                  ) : (
+                    <div className="p-3">
+                      {filteredDestinations.length > 0 && (
+                        <>
+                          <p className="text-xs font-semibold text-muted uppercase tracking-wide px-2 mb-1">Popular destinations</p>
+                          <ul className="mb-2">
+                            {filteredDestinations.slice(0, 6).map((dest) => (
+                              <li key={dest}>
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    setLocation(dest);
+                                    setActive(null);
+                                    goToSearch(dest);
+                                  }}
+                                  className="w-full flex items-center gap-2 px-2 py-2 rounded-lg text-sm text-ink hover:bg-surface-alt transition-colors"
+                                >
+                                  <MapPin className="w-4 h-4 text-brass-dark flex-shrink-0" />
+                                  {dest}
+                                </button>
+                              </li>
+                            ))}
+                          </ul>
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
-          </label>
 
-          <button
-            type="submit"
-            className="flex items-center justify-center gap-2 bg-brass-dark hover:bg-brass text-cream rounded-lg h-11 px-6 transition-colors font-medium"
-          >
-            <Search className="w-4 h-4" aria-hidden="true" />
-            <span className="sm:hidden">Search</span>
-          </button>
+            <div className="hidden lg:block h-8 w-px bg-hairline" aria-hidden="true" />
+
+            {/* TYPE */}
+            <div className="relative">
+              {segment("type", "Type", category ? CATEGORY_LABELS[category] || category : "Any type")}
+              {active === "type" && (
+                <div className="absolute z-30 left-0 mt-2 w-56 bg-surface border border-hairline rounded-xl shadow-luxe p-2 text-left">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setCategory("");
+                      setActive(null);
+                    }}
+                    className={`w-full text-left px-3 py-2 rounded-lg text-sm hover:bg-surface-alt ${!category ? "text-brass-dark font-medium" : "text-ink"}`}
+                  >
+                    Any type
+                  </button>
+                  {categories.map((c) => (
+                    <button
+                      key={c}
+                      type="button"
+                      onClick={() => {
+                        setCategory(c);
+                        setActive(null);
+                      }}
+                      className={`w-full text-left px-3 py-2 rounded-lg text-sm hover:bg-surface-alt ${category === c ? "text-brass-dark font-medium" : "text-ink"}`}
+                    >
+                      {CATEGORY_LABELS[c] || c}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="hidden lg:block h-8 w-px bg-hairline" aria-hidden="true" />
+
+            {/* GUESTS */}
+            <div className="relative">
+              {segment("guests", "Guests", `${guests} guest${guests > 1 ? "s" : ""}`)}
+              {active === "guests" && (
+                <div className="absolute z-30 left-0 mt-2 w-60 bg-surface border border-hairline rounded-xl shadow-luxe p-4 text-left">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-ink">Guests</span>
+                    <div className="flex items-center gap-3">
+                      <button
+                        type="button"
+                        aria-label="Decrease guests"
+                        onClick={() => setGuests((g) => Math.max(1, g - 1))}
+                        className="w-8 h-8 rounded-full border border-hairline flex items-center justify-center text-ink hover:border-brass disabled:opacity-40"
+                        disabled={guests <= 1}
+                      >
+                        <Minus className="w-4 h-4" />
+                      </button>
+                      <span className="w-6 text-center text-sm font-medium text-ink">{guests}</span>
+                      <button
+                        type="button"
+                        aria-label="Increase guests"
+                        onClick={() => setGuests((g) => Math.min(20, g + 1))}
+                        className="w-8 h-8 rounded-full border border-hairline flex items-center justify-center text-ink hover:border-brass"
+                      >
+                        <Plus className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="hidden lg:block h-8 w-px bg-hairline" aria-hidden="true" />
+
+            {/* PRICE */}
+            <div className="relative">
+              {segment("price", "Price", priceLabel)}
+              {active === "price" && (
+                <div className="absolute z-30 right-0 mt-2 w-72 bg-surface border border-hairline rounded-xl shadow-luxe p-4 text-left">
+                  <p className="text-sm text-ink mb-3">Price per night</p>
+                  <div className="flex items-center gap-3">
+                    <label className="flex-1">
+                      <span className="block text-xs text-muted mb-1">Min</span>
+                      <div className="flex items-center border border-hairline rounded-lg px-2 h-10">
+                        <span className="text-muted text-sm">$</span>
+                        <input
+                          type="number"
+                          min={0}
+                          value={minPrice}
+                          onChange={(e) => setMinPrice(e.target.value)}
+                          placeholder={String(priceBounds.min)}
+                          className="w-full outline-none text-sm bg-transparent text-ink px-1"
+                        />
+                      </div>
+                    </label>
+                    <span className="text-muted mt-5">–</span>
+                    <label className="flex-1">
+                      <span className="block text-xs text-muted mb-1">Max</span>
+                      <div className="flex items-center border border-hairline rounded-lg px-2 h-10">
+                        <span className="text-muted text-sm">$</span>
+                        <input
+                          type="number"
+                          min={0}
+                          value={maxPrice}
+                          onChange={(e) => setMaxPrice(e.target.value)}
+                          placeholder={String(priceBounds.max)}
+                          className="w-full outline-none text-sm bg-transparent text-ink px-1"
+                        />
+                      </div>
+                    </label>
+                  </div>
+                  {(minPrice || maxPrice) && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setMinPrice("");
+                        setMaxPrice("");
+                      }}
+                      className="mt-3 text-xs text-brass-dark hover:underline"
+                    >
+                      Clear price
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+
+            <div className="hidden lg:block h-8 w-px bg-hairline" aria-hidden="true" />
+
+            {/* FILTERS (rating + amenities) */}
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setActive((a) => (a === "filters" ? null : "filters"))}
+                className={`flex items-center gap-2 px-4 py-2.5 rounded-full transition-colors hover:bg-surface-alt ${active === "filters" ? "bg-surface-alt" : ""}`}
+              >
+                <SlidersHorizontal className="w-4 h-4 text-ink" />
+                <span className="text-sm text-ink">Filters</span>
+                {filterCount > 0 && (
+                  <span className="min-w-5 h-5 px-1.5 rounded-full bg-brass-dark text-cream text-xs flex items-center justify-center">
+                    {filterCount}
+                  </span>
+                )}
+              </button>
+              {active === "filters" && (
+                <div className="absolute z-30 right-0 mt-2 w-72 bg-surface border border-hairline rounded-xl shadow-luxe p-4 text-left max-h-80 overflow-y-auto">
+                  <p className="text-sm text-ink mb-2">Minimum rating</p>
+                  <div className="flex gap-2 mb-4">
+                    {RATING_OPTIONS.map((r) => (
+                      <button
+                        key={r.value}
+                        type="button"
+                        onClick={() => setMinRating(r.value)}
+                        className={`flex items-center gap-1 px-3 py-1.5 rounded-full border text-sm transition-colors ${
+                          minRating === r.value
+                            ? "bg-brass-dark text-cream border-brass-dark"
+                            : "border-hairline text-ink hover:bg-surface-alt"
+                        }`}
+                      >
+                        {r.value > 0 && <Star className="w-3.5 h-3.5 fill-current" />}
+                        {r.label}
+                      </button>
+                    ))}
+                  </div>
+
+                  {amenityOptions.length > 0 && (
+                    <>
+                      <p className="text-sm text-ink mb-2">Amenities</p>
+                      <div className="space-y-1.5">
+                        {amenityOptions.map((a) => (
+                          <label key={a} className="flex items-center gap-2 text-sm text-ink cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={amenities.includes(a)}
+                              onChange={() => toggleAmenity(a)}
+                              className="accent-brass-dark w-4 h-4"
+                            />
+                            {a}
+                          </label>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* SEARCH */}
+            <button
+              type="submit"
+              className="flex items-center justify-center gap-2 bg-brass-dark hover:bg-brass text-cream rounded-full h-12 lg:h-11 px-6 lg:ml-2 transition-colors font-medium"
+            >
+              <Search className="w-4 h-4" aria-hidden="true" />
+              <span className="lg:hidden">Search</span>
+            </button>
+          </div>
         </form>
       </div>
     </section>


### PR DESCRIPTION
## Hero — segmented search bar
Replaces the generic box with a labeled segmented bar:
**Where** (typeahead) · **Type** · **Guests** (− N + stepper) · **Price** (range) · **Filters** (min rating + amenities) · **Search**

Each segment opens its own popover; the right-side ones are right-aligned so they never cover the search button.

## Real filtering (all wired into results)
New `searchHotels` action — one Mongo aggregation handling **location, guests, category, price range, amenities (`$all`), and min rating** (review lookup only runs when a rating filter is active) with pagination. `getHotels` stays light for the homepage browse listing.

## /search
- Reads every filter param and applies it.
- Renders **removable filter chips** + **Clear all**.
- Pagination preserves the active filters.

## Test plan (verified against dev server)
- [x] Server-side counts: all 62 · beach 5 · luxury 8 · price≥250 → 35 · price≤120 → 6 · rating≥4.5 → 21 · amenity=Spa → 20 · beach+spa → 0 (empty state)
- [x] Hero flow: Type=Luxury + Guests=3 + rating 4+ → `/search?category=luxury&guests=3&minRating=4` → "7 stays"
- [x] Chip removal: remove Luxury → `/search?guests=3&minRating=4` → "52 stays"
- [x] All popovers open/close; search button clickable with a popover open
- [x] Homepage + `/search` compile clean (200)

_Note: `next build` skipped this round — a live `next dev` shares `.next` and a concurrent build corrupts it; verified via the running dev server. Minor pre-existing seed quirk: "Free Wi-Fi" and "Free Wifi" both exist as amenities._

https://claude.ai/code/session_01PqryYY1A7svenYsgfoA9qw