### PR TITLE
feat: hero image crossfade + details skeleton & google-role fixes

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -18,12 +18,19 @@ import { getAllHotels, getHotels, getReviews } from "@/app/action";
 const HERO_FALLBACK =
   "https://images.unsplash.com/photo-1611892440504-42a792e24d32?auto=format&fit=crop&w=2000&q=80";
 
-const pickHeroImage = (hotels) => {
+// A handful of distinct, shuffled hero shots for the Hero to crossfade
+// through. Prefers luxury listings, falls back to any with an image.
+const pickHeroImages = (hotels, count = 5) => {
   const withImages = hotels.filter((h) => h.images?.[0]);
   const luxury = withImages.filter((h) => h.category === "luxury");
-  const pool = luxury.length ? luxury : withImages;
-  if (!pool.length) return HERO_FALLBACK;
-  return pool[Math.floor(Math.random() * pool.length)].images[0];
+  const pool = [
+    ...new Set((luxury.length ? luxury : withImages).map((h) => h.images[0])),
+  ];
+  for (let i = pool.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+  return pool.slice(0, count).length ? pool.slice(0, count) : [HERO_FALLBACK];
 };
 
 const topDestinations = (hotels) => {
@@ -49,7 +56,7 @@ export default async function Home() {
 
   const hotels = allHotelsRes?.hotels ?? [];
   const reviews = reviewsRes?.reviews ?? [];
-  const heroImage = pickHeroImage(hotels);
+  const heroImages = pickHeroImages(hotels);
   const destinations = topDestinations(hotels);
   const categories = [...new Set(hotels.map((h) => h.category))];
   // Slim list for the hero search typeahead - only the fields it renders.
@@ -75,7 +82,7 @@ export default async function Home() {
       <AnnounceBar />
       <Navbar />
       <Hero
-        image={heroImage}
+        images={heroImages}
         destinations={destinations}
         categories={categories}
         hotels={heroHotels}

--- a/auth.js
+++ b/auth.js
@@ -35,7 +35,7 @@ export const {
           name: user.name,
           email: user.email,
           location: user.location,
-          role: user.role,
+          role: user.role || "user",
         };
       }
 

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -3,7 +3,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { motion, useScroll, useTransform, useReducedMotion } from "framer-motion";
+import { AnimatePresence, motion, useScroll, useTransform, useReducedMotion } from "framer-motion";
 import { Search, MapPin, Users, Star, Minus, Plus, SlidersHorizontal, ChevronDown } from "lucide-react";
 
 const FALLBACK_IMAGE =
@@ -31,6 +31,7 @@ const RATING_OPTIONS = [
 
 export default function Hero({
   image,
+  images = [],
   destinations = [],
   categories = [],
   hotels = [],
@@ -62,6 +63,18 @@ export default function Hero({
     offset: ["start start", "end start"],
   });
   const parallaxY = useTransform(scrollYProgress, [0, 1], ["0%", "20%"]);
+
+  // Crossfade through a set of hero shots. Falls back to the single `image`.
+  const heroImages = images.length ? images : [image || FALLBACK_IMAGE];
+  const [heroIndex, setHeroIndex] = useState(0);
+  useEffect(() => {
+    if (prefersReducedMotion || heroImages.length < 2) return;
+    const id = setInterval(
+      () => setHeroIndex((i) => (i + 1) % heroImages.length),
+      6000
+    );
+    return () => clearInterval(id);
+  }, [prefersReducedMotion, heroImages.length]);
 
   // Height = viewport minus the announce bar + navbar, so together they read
   // as exactly one screen. Recomputes on announce dismiss / resize.
@@ -161,7 +174,28 @@ export default function Hero({
         style={{ y: prefersReducedMotion ? 0 : parallaxY }}
         className="absolute inset-x-0 -top-[10%] h-[120%]"
       >
-        <Image src={image || FALLBACK_IMAGE} alt="Featured hotel" fill priority sizes="100vw" className="object-cover" />
+        <AnimatePresence>
+          <motion.div
+            key={heroIndex}
+            initial={prefersReducedMotion ? false : { opacity: 0, scale: 1.08 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{
+              opacity: { duration: 1.6, ease: "easeInOut" },
+              scale: { duration: 7, ease: "linear" },
+            }}
+            className="absolute inset-0"
+          >
+            <Image
+              src={heroImages[heroIndex]}
+              alt="Featured hotel"
+              fill
+              priority={heroIndex === 0}
+              sizes="100vw"
+              className="object-cover"
+            />
+          </motion.div>
+        </AnimatePresence>
       </motion.div>
       <div className="absolute inset-0 bg-gradient-to-t from-ink via-ink/50 to-ink/10" aria-hidden="true" />
 

--- a/components/skeletons/DetailsPageSkeleton.jsx
+++ b/components/skeletons/DetailsPageSkeleton.jsx
@@ -12,7 +12,7 @@ const DetailsPageSkeleton = () => {
       </div>
 
       <div className="hotel-image-grid mb-8">
-        {[...Array(4)].map((_, index) => (
+        {[...Array(5)].map((_, index) => (
           <Skeleton key={index} className="w-full h-full rounded-lg" />
         ))}
       </div>


### PR DESCRIPTION
## Changes
- **Hero crossfade**: cycles through several listing images with a smooth crossfade + slow Ken-Burns zoom (6s, respects reduced-motion). `page.js` supplies a shuffled set via `pickHeroImages`.
- **Details skeleton**: gallery placeholders 4 → 5 to match the real 5-image grid (1 large + 4).
- **Google role**: jwt callback defaults `role` to `"user"`, so Google sign-ins get the same profile-dropdown menu as credential users (Mongo adapter never set a role).

## Test
- Home: hero fades between images every 6s
- `/details/:id`: skeleton shows 5 gallery blocks
- Sign in with Google → dropdown shows Create Hotel / Manage / Bookings / Wishlists / Profile

https://claude.ai/code/session_018gDSz8EMfC5vuMXSAyp3Yn