### PR TITLE
fix: dashboard content fills full width

### DIFF
--- a/app/dashboard/bookings-list/page.js
+++ b/app/dashboard/bookings-list/page.js
@@ -11,7 +11,7 @@ export default async function Bookings() {
   const { bookings } = await getBookings();
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+    <div className="px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
       <h1 className="font-serif text-2xl sm:text-3xl text-ink mb-4 sm:mb-6">Bookings</h1>
       <BookingsList bookings={bookings} />
     </div>

--- a/app/dashboard/bookings/page.js
+++ b/app/dashboard/bookings/page.js
@@ -16,7 +16,7 @@ export default async function Bookings() {
   );
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-8">
+    <div className="px-4 py-8">
       <h1 className="font-serif text-3xl text-ink mb-6">My Bookings</h1>
       <BookingDetailsModal bookings={filteredBookings} />
     </div>

--- a/app/dashboard/create-hotel/page.js
+++ b/app/dashboard/create-hotel/page.js
@@ -247,7 +247,7 @@ const HotelForm = () => {
   return (
     <>
       <form onSubmit={handleSubmit}>
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 relative bg-cream">
+        <div className="px-4 sm:px-6 lg:px-8 py-6 sm:py-8 relative bg-cream">
           <button
             type="submit"
             className={`flex items-center px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg absolute top-4 right-4 sm:right-6 text-sm sm:text-base transition-colors ${

--- a/app/dashboard/hotels-list/page.js
+++ b/app/dashboard/hotels-list/page.js
@@ -16,7 +16,7 @@ export default async function ManageHotel() {
     const { reviews } = await getReviews();
 
     return (
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+        <div className="px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
             <div className="flex flex-col sm:flex-row justify-between items-center mb-6 sm:mb-8 gap-4">
                 <h1 className="font-serif text-2xl sm:text-3xl text-ink">Manage Hotels</h1>
                 <Link

--- a/app/dashboard/manage-hotels/page.js
+++ b/app/dashboard/manage-hotels/page.js
@@ -22,7 +22,7 @@ export default async function ManageHotel() {
   );
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+    <div className="px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
       <div className="flex flex-col sm:flex-row justify-between items-center mb-6 sm:mb-8 gap-4">
         <h1 className="font-serif text-2xl sm:text-3xl text-ink">
           Manage Hotels

--- a/app/dashboard/profile/page.js
+++ b/app/dashboard/profile/page.js
@@ -35,7 +35,7 @@ const Profile = async () => {
 
   return (
     <div className="min-h-screen bg-cream">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="px-4 sm:px-6 lg:px-8 py-8">
         <div className="relative bg-surface rounded-2xl border border-hairline shadow-sm overflow-hidden mb-8">
           <div className="relative p-8">
             <div className="flex flex-col sm:flex-row items-center sm:items-start space-y-4 sm:space-y-0 sm:space-x-6">

--- a/app/dashboard/users-list/page.js
+++ b/app/dashboard/users-list/page.js
@@ -153,7 +153,7 @@ export default function UsersList() {
 
   if (loading) {
     return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+      <div className="px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
         <div className="mb-6 sm:mb-8">
           <Skeleton className="h-8 sm:h-10 w-48 rounded-lg" />
           <Skeleton className="h-4 w-72 mt-2 rounded" />
@@ -173,7 +173,7 @@ export default function UsersList() {
 
   if (error) {
     return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+      <div className="px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
         <div className="mb-6 sm:mb-8">
           <h1 className="font-serif text-2xl sm:text-3xl text-ink mb-2">
             Users List
@@ -207,7 +207,7 @@ export default function UsersList() {
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+    <div className="px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 sm:gap-6 mb-6 sm:mb-8">
         <div className="flex-1">
           <h1 className="font-serif text-2xl sm:text-3xl text-ink mb-1 sm:mb-2">

--- a/app/dashboard/wishlists-list/page.js
+++ b/app/dashboard/wishlists-list/page.js
@@ -68,7 +68,7 @@ export default function WishlistPage() {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-8">
+      <div className="w-full px-4 py-8">
         <div className="text-center">
           <Loader2 className="h-12 w-12 mx-auto animate-spin text-brass-dark" />
           <p className="mt-4 text-muted">Loading wishlist...</p>
@@ -78,7 +78,7 @@ export default function WishlistPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="w-full px-4 py-8">
       <h1 className="font-serif text-2xl text-ink mb-6">Wishlists</h1>
       {wishlistNotBooked.length > 0 ? (
         <>

--- a/app/dashboard/wishlists/page.js
+++ b/app/dashboard/wishlists/page.js
@@ -19,7 +19,7 @@ export default async function WishlistPage({ searchParams }) {
   } catch (error) {
     console.error("Error fetching data:", error);
     return (
-      <div className="max-w-7xl mx-auto px-4 py-8">
+      <div className="px-4 py-8">
         <h1 className="font-serif text-2xl text-ink mb-6">My Wishlist</h1>
         <div className="text-center py-12">
           <h2 className="text-xl sm:text-2xl font-semibold text-red-500">
@@ -51,7 +51,7 @@ export default async function WishlistPage({ searchParams }) {
   );
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-8">
+    <div className="px-4 py-8">
       <h1 className="font-serif text-2xl text-ink mb-6">My Wishlist</h1>
       <WishlistList wishlistNotBooked={wishlistNotBooked} searchParams={searchParams} />
     </div>


### PR DESCRIPTION
## Why
Every dashboard page capped content at `max-w-7xl mx-auto` (wishlists-list used `container mx-auto`), centering it and leaving right-side whitespace on wide screens.

## What
Dropped the cap across all dashboard pages — content fills the main column next to the sidebar. Admin root already used `flex-1`. Icon/empty-state `mx-auto` left intact.

https://claude.ai/code/session_018gDSz8EMfC5vuMXSAyp3Yn