### PR TITLE
fix: escape Navbar quotes to unblock production build

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -212,7 +212,7 @@ const Navbar = () => {
                 ))}
               </ul>
             ) : (
-              <p className="px-4 py-3 text-sm text-muted">No matches for "{searchValue.trim()}"</p>
+              <p className="px-4 py-3 text-sm text-muted">No matches for &quot;{searchValue.trim()}&quot;</p>
             )}
             <button
               type="button"
@@ -220,7 +220,7 @@ const Navbar = () => {
               className="w-full flex items-center gap-2 px-4 py-2.5 border-t border-hairline text-sm text-brass-dark hover:bg-surface-alt transition-colors font-medium"
             >
               <Search className="w-4 h-4" />
-              Search all stays for "{searchValue.trim()}"
+              Search all stays for &quot;{searchValue.trim()}&quot;
             </button>
           </div>
         )}


### PR DESCRIPTION
## Why
Vercel prod builds failed: `next build` runs ESLint and `react/no-unescaped-entities` errored on literal `"` in `Navbar.jsx` (215, 223), exiting with code 1. Dev doesn't lint, so it only appeared in production.

## What
Escaped the quotes with `&quot;` in the typeahead "No matches" and "Search all stays for" strings. `next lint` is now clean across the whole repo (verified), so the lint step that broke the build passes.

https://claude.ai/code/session_018gDSz8EMfC5vuMXSAyp3Yn